### PR TITLE
Added more functions, made print_all_status forgivable.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build/
 dist/
 *.egg-info
 apk/
+daikin_altherma/__pycache__/

--- a/README.md
+++ b/README.md
@@ -186,8 +186,8 @@ look at the [example file](example.py).
      |  unit_type
      |      Returns the type of unit
      | 
-     |  in_installerstate
-     |      Returns if the heating is in the installer mode, will have limited functionality
+     |  in_installerstate and tank_in_installerstate
+     |      Returns if the heating is in the installer mode, will have limited functionality in that case
      |
      |  ----------------------------------------------------------------------
      |  Data descriptors defined here:

--- a/README.md
+++ b/README.md
@@ -1,12 +1,16 @@
 # python-daikin-altherma
+
 talks to daikin altherma via LAN adapter BRP069A61 or BRP069A62
 
 # How to use
+
 ## How to install ?
+
 Simply get it from [pypi](https://pypi.org/project/python-daikin-altherma/) by:
 `pip3 install python-daikin-altherma`
 
 ## How to run
+
 ```python3
 >>> from daikin_altherma import DaikinAltherma
 >>> d = DaikinAltherma('192.168.10.126')
@@ -30,11 +34,13 @@ Heating:
 ```
 
 ## Schedules
+
 You can set schedules using `set_heating_schedule(schedule)`. Your best bet is to
 look at the [example file](example.py).
 
 # Documentation
-```
+
+```text
     class DaikinAltherma(builtins.object)
      |  DaikinAltherma(adapter_ip: str)
      |  
@@ -58,20 +64,27 @@ look at the [example file](example.py).
      |  
      |  set_setpoint_temperature(self, setpoint_temperature_c: float)
      |      Sets the heating setpoint (target) temperature, in °C
+     |
+     |  set_leaving_water_temperature_offset(self, offset_temperature_c: int)
+     |      Sets the heating leaving water offset temperature, in °C
      |  
      |  set_tank_heating_enabled(self, powerful_active: bool)
      |      Whether to turn the water tank heating on(True) or off(False).
      |      You can confirm that it works by calling self.is_tank_heating_enabled
      |  
      |  set_unit_datetime(self, d)
-     |      Sets the datetime of your unit. Does not work on all units
+     |      Sets the datetime of your unit. Does not work on all units. See `is_unit_datetime_adjustable`
      |  
      |  ----------------------------------------------------------------------
-     |  Readonly properties defined here:
+     |  Readonly properties/methods defined here:
+     |      All properties will return None if not supported.
      |  
      |  adapter_model
      |      Returns the model of the LAN adapter.
      |      Ex: BRP069A61
+     |
+     |  available_services(unit_nr)
+     |      returns a JSON with capacities for each unit. unit_nr is in range [0..2] normally
      |  
      |  heating_mode
      |      This function name makes no sense, because it
@@ -106,9 +119,15 @@ look at the [example file](example.py).
      |  
      |  is_tank_powerful
      |      Returns if the tank is in powerful state
+     |
+     |  is_unit_datetime_adjustable
+     |      Returns True if the datetime of your unit is adjustable
      |  
      |  leaving_water_temperature
      |      Returns the heating leaving water temperature, in °C
+     |  
+     |  leaving_water_temperature_offset
+     |      Returns the heating leaving water offset temperature, in °C
      |  
      |  outdoor_temperature
      |      Returns the outdoor temperature, in °C
@@ -120,7 +139,7 @@ look at the [example file](example.py).
      |      Returns the pin code of the LAN adapter
      |  
      |  power_consumption
-     |      Returns the energy consumption in kWh per [D]ay, [W]eek, [M]onth
+     |      Returns the heating energy consumption in kWh per [D]ay, [W]eek, [M]onth
      |  
      |  remote_setting_version
      |      Returns the remote console setting version
@@ -139,6 +158,9 @@ look at the [example file](example.py).
      |  
      |  tank_temperature
      |      Returns the hot water tank temperature, in °C
+     |
+     |  tank_power_consumption
+     |      Returns the tank energy consumption in kWh per [D]ay, [W]eek, [M]onth
      |  
      |  unit_datetime
      |      Returns the current date of the unit. Is refreshed every minute or so
@@ -149,7 +171,10 @@ look at the [example file](example.py).
      |  
      |  unit_type
      |      Returns the type of unit
-     |  
+     | 
+     |  in_installerstate
+     |      Returns if the heating is in the installer mode, will have limited functionality
+     |
      |  ----------------------------------------------------------------------
      |  Data descriptors defined here:
      |  
@@ -170,6 +195,7 @@ look at the [example file](example.py).
 ```
 
 # Acknowledgments
+
 Many thanks to [william-sy](https://github.com/william-sy/Daikin-BRP069A62) and [KarstenB](https://github.com/KarstenB/DaikinAltherma) for their bootstrap !
 
 # Alternatives

--- a/README.md
+++ b/README.md
@@ -84,11 +84,13 @@ look at the [example file](example.py).
      |      Ex: BRP069A61
      |
      |  available_services(unit_nr)
-     |      returns a JSON with capacities for each unit. unit_nr is in range [0..2] normally
+     |      Returns a JSON with capacities for each unit. unit_nr is in range [0..2] normally
      |  
+     |  control_mode
+     |      Returns the type of control used for heating. This is an installation setting, and controls for example the availability of indoor_temperature 
+     |
      |  heating_mode
-     |      This function name makes no sense, because it
-     |      returns whether the heat pump is heating or cooling.
+     |      Returns whether the heat pump is heating or cooling.
      |  
      |  heating_schedule
      |      Returns the HeatingSchedule list heating
@@ -110,12 +112,24 @@ look at the [example file](example.py).
      |  
      |  is_heating_enabled
      |      Returns if the unit heating is enabled
+     |
+     |  is_heating_[warning|error|emergency]
+     |      Returns if heating has a warning or an error or an emergency
+     |
+     |  heating_error_status
+     |      Returns the heating status: "OK" or "Warning" or "Error" or "Emergency"     
      |  
      |  is_holiday_mode
      |      Returns if the holiday mode active or not
      |  
      |  is_tank_heating_enabled
      |      Returns if the tank heating is currently enabled
+     |
+     |  is_tank_[warning|error|emergency]
+     |      Returns if tank heating has a warning or an error or an emergency
+     |
+     |  tank_error_status
+     |      Returns the tank status: "OK" or "Warning" or "Error" or "Emergency"
      |  
      |  is_tank_powerful
      |      Returns if the tank is in powerful state

--- a/daikin_altherma/__init__.py
+++ b/daikin_altherma/__init__.py
@@ -134,7 +134,7 @@ class DaikinAltherma:
         """Returns the model of the LAN adapter.
         Ex: BRP069A61"""
         # either BRP069A61 or BRP069A62
-        return self._requestValue("MNCSE-node/deviceInfo", "/m2m:rsp/pc/m2m:dvi/mod")
+        return self._requestValue("MNCSE-node/deviceInfo", "/m2m:rsp/pc/m2m:dvi/mod")  # "NOT /m2m:rsp/pc/m2m:cin/con"
 
     @property
     def unit_datetime(self) -> datetime.datetime:
@@ -205,8 +205,7 @@ class DaikinAltherma:
     @property
     def remote_setting_version(self) -> str:
         """Returns the remote console setting version"""
-        return self._requestValueHP(
-            "1/UnitInfo/Version/RemoconSettings/la")
+        return self._requestValueHP("1/UnitInfo/Version/RemoconSettings/la")
 
     @property
     def remote_software_version(self) -> str:
@@ -258,14 +257,12 @@ class DaikinAltherma:
     @property
     def tank_temperature(self) -> float:
         """Returns the hot water tank temperature, in °C"""
-        return self._requestValueHP(
-            "2/Sensor/TankTemperature/la")
+        return self._requestValueHP("2/Sensor/TankTemperature/la")
 
     @property
     def tank_setpoint_temperature(self) -> float:
         """Returns the hot water tank setpoint (target) temperature, in °C"""
-        return self._requestValueHP(
-            "2/Operation/TargetTemperature/la")
+        return self._requestValueHP("2/Operation/TargetTemperature/la")
 
     @property
     def is_tank_heating_enabled(self) -> bool:
@@ -308,20 +305,17 @@ class DaikinAltherma:
     @property
     def indoor_temperature(self) -> float:
         """Returns the indoor temperature, in °C"""
-        return self._requestValueHP(
-            "1/Sensor/IndoorTemperature/la")
+        return self._requestValueHP("1/Sensor/IndoorTemperature/la")
 
     @property
     def outdoor_temperature(self) -> float:
         """Returns the outdoor temperature, in °C"""
-        return self._requestValueHP(
-            "1/Sensor/OutdoorTemperature/la")
+        return self._requestValueHP("1/Sensor/OutdoorTemperature/la")
 
     @property
     def indoor_setpoint_temperature(self) -> float:
         """Returns the indoor setpoint (target) temperature, in °C"""
-        return self._requestValueHP(
-            "1/Operation/TargetTemperature/la")
+        return self._requestValueHP("1/Operation/TargetTemperature/la")
 
     @property
     def leaving_water_temperature(self) -> float:
@@ -467,8 +461,7 @@ class DaikinAltherma:
     @property
     def tank_schedule(self) -> list[TankSchedule]:
         """Returns the TankSchedule list heating"""
-        d = self._requestValueHP(
-            "2/Schedule/List/Heating/la")
+        d = self._requestValueHP("2/Schedule/List/Heating/la")
         j = json.loads(d)
         if j is None:
             return []

--- a/daikin_altherma/__init__.py
+++ b/daikin_altherma/__init__.py
@@ -120,6 +120,8 @@ class DaikinAltherma:
     def unit_datetime(self) -> datetime.datetime:
         """Returns the current date of the unit. Is refreshed every minute or so"""
         d = self._requestValueHP("0/DateTime/la", "/m2m:rsp/pc/m2m:cin/con")
+        if d is None:
+            return None
         return datetime.datetime.strptime(d, self.DATETIME_FMT)
 
     @property
@@ -393,6 +395,15 @@ class DaikinAltherma:
             return None
         else:
             return (r == 1)
+        
+    @property
+    def in_installerstate(self) -> bool:
+        """Returns if the heating has an error"""
+        r = self._requestValueHP("1/UnitStatus/InstallerState/la", "/m2m:rsp/pc/m2m:cin/con")
+        if r is None:
+            return None
+        else:
+            return (r == 1)
 
     @property
     def tank_schedule(self) -> list[TankSchedule]:
@@ -472,6 +483,7 @@ class DaikinAltherma:
             return None
         else:
             return (r == 1)
+        
     @property
     def is_tank_emergency(self) -> bool:
         """Returns if the tank is in emergency state"""
@@ -481,7 +493,16 @@ class DaikinAltherma:
         else:
             return (r == 1)
         
-    def print_all_status(self):
+    @property
+    def tank_in_installerstate(self) -> bool:
+        """Returns if the heating has an error"""
+        r = self._requestValueHP("2/UnitStatus/InstallerState/la", "/m2m:rsp/pc/m2m:cin/con")
+        if r is None:
+            return None
+        else:
+            return (r == 1)        
+        
+    def print_all_status(self, without_schedule: bool = False):
         print(
             f"""
 Daikin adapter: {self.adapter_ip} {self.adapter_model}
@@ -497,9 +518,10 @@ Hot water tank:
     Current: {self.tank_temperature}°C (target {self.tank_setpoint_temperature}°C)
     Heating enabled: {self.is_tank_heating_enabled} (Powerful: {self.is_tank_powerful}) (Active: {self.is_tank_active})
     Error: {self.is_tank_error} (Emergency: {self.is_tank_emergency})
-    Schedules: {self.tank_schedule}
+    Schedules: {"(excluded from print)" if without_schedule else self.tank_schedule}
     Schedule state: {self.tank_schedule_state}
     Consumption: {self.tank_power_consumption}
+    Installer state: {self.tank_in_installerstate}
 Heating:
     Outdoor temp:{self.outdoor_temperature}°C
     Indoor temp: {self.indoor_temperature}°C
@@ -507,9 +529,10 @@ Heating:
     Error: {self.is_heating_error} (Emergency: {self.is_heating_emergency})
     Leaving water: {self.leaving_water_temperature}°C
     Heating mode: {self.heating_mode}
-    Schedules: {self.heating_schedule}
+    Schedules: {"(excluded from print)" if without_schedule else self.heating_schedule}
     Schedule state: {self.heating_schedule_state}
     Consumption: {self.power_consumption}
+    Installer state: {self.in_installerstate}
 Holiday mode: {self.is_holiday_mode}
     """
         )

--- a/daikin_altherma/__init__.py
+++ b/daikin_altherma/__init__.py
@@ -451,7 +451,7 @@ class DaikinAltherma:
         
     @property
     def in_installerstate(self) -> bool:
-        """Returns if the heating is in the installer mode, will have limited functionality"""
+        """Returns if the heating is in the installer mode, will have limited functionality in that case"""
         r = self._requestValueHP("1/UnitStatus/InstallerState/la")
         if r is None:
             return None
@@ -561,7 +561,7 @@ class DaikinAltherma:
         
     @property
     def tank_in_installerstate(self) -> bool:
-        """Returns if the tank heating is in the installer mode, will have limited functionality"""
+        """Returns if the tank heating is in the installer mode, will have limited functionality in that case"""
         r = self._requestValueHP("2/UnitStatus/InstallerState/la")
         if r is None:
             return None

--- a/daikin_altherma/__init__.py
+++ b/daikin_altherma/__init__.py
@@ -3,7 +3,6 @@ from typing import Callable
 from dataclasses import dataclass
 import enum
 import logging
-import time
 import uuid
 import datetime
 
@@ -39,15 +38,18 @@ class HeatingOperationMode(str, enum.Enum):
     Heating = 'Heating'
     Cooling = 'Cooling'
 
+
 @dataclass
 class _ScheduleState:
     OperationMode: HeatingOperationMode
     StartTime: int
-    Day: str ## XXX enum
+    Day: str  # XXX enum
+
 
 @dataclass
 class HeatingScheduleState(_ScheduleState):
     TargetTemperature: float
+
 
 @dataclass
 class TankScheduleState(_ScheduleState):
@@ -57,8 +59,10 @@ class TankScheduleState(_ScheduleState):
 class DaikinAltherma:
     UserAgent = "python-daikin-altherma"
     DAYS = ["Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"]
-    _heating_value_parser = lambda x: float(x)/10
     DATETIME_FMT = "%Y%m%dT%H%M%SZ"
+        
+    def _heating_value_parser(x):
+        return float(x) / 10
 
     def __init__(self, adapter_ip: str):
         self.adapter_ip = adapter_ip
@@ -128,7 +132,6 @@ class DaikinAltherma:
         }
         print(self._requestValueHP("0/DateTime", "/", payload))
 
-
     @property
     def unit_model(self) -> str:
         """Returns the model of the heating unit.
@@ -182,7 +185,6 @@ class DaikinAltherma:
         """Returns the pin code of the LAN adapter"""
         return self._requestValueHP("1/ChildLock/PinCode/la", "/m2m:rsp/pc/m2m:cin/con")
 
-
     @property
     def is_holiday_mode(self) -> bool:
         """ Returns if the holiday mode active or not """
@@ -224,16 +226,14 @@ class DaikinAltherma:
     def is_tank_heating_enabled(self) -> bool:
         """Returns if the tank heating is currently enabled"""
         return (
-            self._requestValueHP("2/Operation/Power/la", "m2m:rsp/pc/m2m:cin/con")
-            == "on"
+            self._requestValueHP("2/Operation/Power/la", "m2m:rsp/pc/m2m:cin/con") == "on"
         )
 
     @property
     def is_tank_powerful(self) -> bool:
         """Returns if the tank is in powerful state"""
         return (
-            self._requestValueHP("2/Operation/Powerful/la", "m2m:rsp/pc/m2m:cin/con")
-            == 1
+            self._requestValueHP("2/Operation/Powerful/la", "m2m:rsp/pc/m2m:cin/con") == 1
         )
 
     def set_tank_heating_enabled(self, powerful_active: bool):
@@ -285,8 +285,7 @@ class DaikinAltherma:
     def is_heating_enabled(self) -> bool:
         """Returns if the unit heating is enabled"""
         return (
-            self._requestValueHP("1/Operation/Power/la", "m2m:rsp/pc/m2m:cin/con")
-            == "on"
+            self._requestValueHP("1/Operation/Power/la", "m2m:rsp/pc/m2m:cin/con") == "on"
         )
 
     @property
@@ -383,7 +382,6 @@ class DaikinAltherma:
         }
         self._requestValueHP("1/Schedule/List/Heating", "/", payload)
 
-
     @property
     def heating_schedule_state(self) -> HeatingScheduleState:
         """Returns the actual heating schedule state"""
@@ -408,7 +406,7 @@ class DaikinAltherma:
         return TankScheduleState(
             OperationMode=dq['OperationMode'],
             StartTime=dq['StartTime'],
-            TankState=TankStateEnum.int_to_state(dq['TargetTemperature']),  #Copy paste powa
+            TankState=TankStateEnum.int_to_state(dq['TargetTemperature']),  # Copy paste powa
             Day=dq['Day'],
         )
 
@@ -426,7 +424,6 @@ class DaikinAltherma:
     def is_tank_emergency(self) -> bool:
         """Returns if the tank is in emergency state"""
         return self._requestValueHP("2/UnitStatus/EmergencyState/la", "/m2m:rsp/pc/m2m:cin/con") == 1
-
 
     def print_all_status(self):
         print(
@@ -465,7 +462,7 @@ Heating:
 
         for day in DaikinAltherma.DAYS:
             schedule_wk = {}
-            temps = hrs[i : i + 6]
+            temps = hrs[i: i + 6]
             for c in temps:
                 ctime, cval = c.split(",")
                 if ctime == "":
@@ -490,7 +487,7 @@ Heating:
 
             assert len(sday) <= 6
             for hour in sorted(sday.keys()):
-                schedule_day.append(f"{hour},{int(sday[hour]*10)}")
+                schedule_day.append(f"{hour},{int(sday[hour] * 10)}")
             padding_schedule = 6 - len(schedule_day)
             schedule_day += [","] * padding_schedule
             week_schedule += schedule_day

--- a/daikin_altherma/__init__.py
+++ b/daikin_altherma/__init__.py
@@ -97,7 +97,7 @@ class DaikinAltherma:
         try:
             return dpath.util.get(result, output_path)
         except KeyError:
-            logging.error(f"Could not get data for item {item}. Maybe the unit is starting up?")
+            logging.error(f"Could not get data for item {item}. Maybe the unit is starting up or relevant module is not installed?")
             return None
 
     def _requestValueHP(self, item: str, output_path: str, payload=None):
@@ -121,6 +121,18 @@ class DaikinAltherma:
         """Returns the current date of the unit. Is refreshed every minute or so"""
         d = self._requestValueHP("0/DateTime/la", "/m2m:rsp/pc/m2m:cin/con")
         return datetime.datetime.strptime(d, self.DATETIME_FMT)
+
+    @property
+    def is_unit_datetime_adjustable(self) -> bool:
+        """Returns True if the datetime of your unit is adjustable"""
+        d = self._requestValueHP("0/UnitProfile/la", "/m2m:rsp/pc/m2m:cin/con")
+        if d is None:
+            return False
+        j = json.loads(d)
+        try:
+            return j["DateTime"]["DateTimeAdjustable"]
+        except KeyError:
+            return None
 
     def set_unit_datetime(self, d):
         """Sets the datetime of your unit. Does not work on all units"""
@@ -188,8 +200,10 @@ class DaikinAltherma:
     @property
     def is_holiday_mode(self) -> bool:
         """ Returns if the holiday mode active or not """
-        hs = self._requestValueHP("1/Holiday/HolidayState/la", "/m2m:rsp/pc/m2m:cin/con")
-        return hs == 1
+        r = self._requestValueHP("1/Holiday/HolidayState/la", "/m2m:rsp/pc/m2m:cin/con")
+        if r is None:
+            return None
+        return r == 1
 
     def set_holiday_mode(self, on_holiday: bool):
         """ Whether to turn the holiday mode on(True) or off(False).
@@ -225,16 +239,20 @@ class DaikinAltherma:
     @property
     def is_tank_heating_enabled(self) -> bool:
         """Returns if the tank heating is currently enabled"""
-        return (
-            self._requestValueHP("2/Operation/Power/la", "m2m:rsp/pc/m2m:cin/con") == "on"
-        )
+        r = self._requestValueHP("2/Operation/Power/la", "m2m:rsp/pc/m2m:cin/con")
+        if r is None:
+            return None
+        else:
+            return (r == "on")
 
     @property
     def is_tank_powerful(self) -> bool:
         """Returns if the tank is in powerful state"""
-        return (
-            self._requestValueHP("2/Operation/Powerful/la", "m2m:rsp/pc/m2m:cin/con") == 1
-        )
+        r = self._requestValueHP("2/Operation/Powerful/la", "m2m:rsp/pc/m2m:cin/con")
+        if r is None:
+            return None
+        else:
+            return (r == 1)
 
     def set_tank_heating_enabled(self, powerful_active: bool):
         """Whether to turn the water tank heating on(True) or off(False).
@@ -284,9 +302,11 @@ class DaikinAltherma:
     @property
     def is_heating_enabled(self) -> bool:
         """Returns if the unit heating is enabled"""
-        return (
-            self._requestValueHP("1/Operation/Power/la", "m2m:rsp/pc/m2m:cin/con") == "on"
-        )
+        r = self._requestValueHP("1/Operation/Power/la", "m2m:rsp/pc/m2m:cin/con")
+        if r is None:
+            return None
+        else:
+            return (r == "on")
 
     @property
     def heating_mode(self) -> str:
@@ -350,17 +370,29 @@ class DaikinAltherma:
     @property
     def is_heating_error(self) -> bool:
         """Returns if the heating has an error"""
-        return self._requestValueHP("1/UnitStatus/ErrorState/la", "/m2m:rsp/pc/m2m:cin/con") == 1
+        r = self._requestValueHP("1/UnitStatus/ErrorState/la", "/m2m:rsp/pc/m2m:cin/con")
+        if r is None:
+            return None
+        else:
+            return (r == 1)
 
     @property
     def is_heating_active(self) -> bool:
         """Returns if the heating is currently active"""
-        return self._requestValueHP("1/UnitStatus/ActiveState/la", "/m2m:rsp/pc/m2m:cin/con") == 1
+        r = self._requestValueHP("1/UnitStatus/ActiveState/la", "/m2m:rsp/pc/m2m:cin/con")
+        if r is None:
+            return None
+        else:
+            return (r == 1)
 
     @property
     def is_heating_emergency(self) -> bool:
         """Returns if the heating is in emergency state"""
-        return self._requestValueHP("1/UnitStatus/EmergencyState/la", "/m2m:rsp/pc/m2m:cin/con") == 1
+        r = self._requestValueHP("1/UnitStatus/EmergencyState/la", "/m2m:rsp/pc/m2m:cin/con")
+        if r is None:
+            return None
+        else:
+            return (r == 1)
 
     @property
     def tank_schedule(self) -> list[TankSchedule]:
@@ -426,24 +458,41 @@ class DaikinAltherma:
     @property
     def is_tank_error(self) -> bool:
         """Returns if the tank has an error"""
-        return self._requestValueHP("2/UnitStatus/ErrorState/la", "/m2m:rsp/pc/m2m:cin/con") == 1
+        r = self._requestValueHP("2/UnitStatus/ErrorState/la", "/m2m:rsp/pc/m2m:cin/con")
+        if r is None:
+            return None
+        else:
+            return (r == 1)
 
     @property
     def is_tank_active(self) -> bool:
         """Returns if the tank is currently active"""
-        return self._requestValueHP("2/UnitStatus/ActiveState/la", "/m2m:rsp/pc/m2m:cin/con") == 1
-
+        r = self._requestValueHP("2/UnitStatus/ActiveState/la", "/m2m:rsp/pc/m2m:cin/con")
+        if r is None:
+            return None
+        else:
+            return (r == 1)
     @property
     def is_tank_emergency(self) -> bool:
         """Returns if the tank is in emergency state"""
-        return self._requestValueHP("2/UnitStatus/EmergencyState/la", "/m2m:rsp/pc/m2m:cin/con") == 1
-
+        r = self._requestValueHP("2/UnitStatus/EmergencyState/la", "/m2m:rsp/pc/m2m:cin/con")
+        if r is None:
+            return None
+        else:
+            return (r == 1)
+        
     def print_all_status(self):
         print(
             f"""
 Daikin adapter: {self.adapter_ip} {self.adapter_model}
 Daikin unit: {self.unit_model} {self.unit_type}
-Daikin time: {self.unit_datetime}
+Daikin time: {self.unit_datetime} (adjustable: {self.is_unit_datetime_adjustable})
+Software versions:
+    Indoor: {self.indoor_unit_software_version}
+    Outdoor: {self.outdoor_unit_software_version}
+    Remote settings: {self.remote_setting_version}
+    Remote software: {self.remote_software_version}
+    Pin code: {self.pin_code}
 Hot water tank:
     Current: {self.tank_temperature}°C (target {self.tank_setpoint_temperature}°C)
     Heating enabled: {self.is_tank_heating_enabled} (Powerful: {self.is_tank_powerful}) (Active: {self.is_tank_active})
@@ -461,6 +510,7 @@ Heating:
     Schedules: {self.heating_schedule}
     Schedule state: {self.heating_schedule_state}
     Consumption: {self.power_consumption}
+Holiday mode: {self.is_holiday_mode}
     """
         )
 


### PR DESCRIPTION
* extra functions/properties:
  * leaving_water_temperature_offset
  * set_leaving_water_temperature_offset
  * is_unit_datetime_adjustable
  * available_services (no longer hidden)
  * control_mode
  * is_heating_warning
  * is_tank_warning
  * tank_power_consumption
  * in_installerstate
  * tank_in_installerstate
  * heating_error_status
  * tank_error_status
* included most of them in readme and dump_all_status
* added some other queries in the comments for potential future use
* lint cleanups (also in readme)
* added more documentation
* simplified code a bit: less duplicate text (see 2nd parameter of `_requestValueHP()`)
* adapted `dump_all_status()` to gracefully accept not supported queries, and to not print the schedule if desired so (less clutter)
* The setters return a boolean showing success of not (well, at least if the query was supported or not)
* Instead of throwing exceptions, the properties now return 'None' if the query is not supported

The last one is admittedly more of a code style issue, but it surely helps `dump_all_status()` and thereby makes onboarding much easier (avoiding problems like #8). It does make unsupported operations less obvious. However, the list of unsupported operations don't just change overnight, it requires a physical intervention, so the risk is very low.


Output example of `dump_all_status(True)`:

```text
Daikin adapter: 192.168.4.188 BRP069A62
Daikin unit: EHYHBH08AAV3 3
Daikin time: 2025-03-21 15:51:38 (adjustable: False)
Software versions:
    Indoor: ID9051
    Outdoor: ID3904
    Remote settings: AS1705847-01F
    Remote software: v01.19.00
    Pin code: 1234
Hot water tank:
    Current: 62.0°C (target 50.0°C)
    Heating enabled: True (Powerful: False) (Active: False)
    Status: OK
    Schedules: (excluded from print)
    Schedule state: TankScheduleState(OperationMode='Heating', StartTime=1600, Day=4, TankState=<TankStateEnum.ECO: 'eco'>)
    Consumption: --not supported--
    Installer state: False
Heating:
    Control mode: ext RT control
    Outdoor temp: 19.0°C
    Indoor temp: --not supported--°C (target --not supported--°C)
    Heating enabled: True (Active: True)
    Status: OK
    Leaving water: 38.0°C
    Leaving water offset: 0.0°C
    Heating mode: heating
    Schedules: (excluded from print)
    Schedule state: --not supported--
    Consumption: --not supported--
    Installer state: False
Holiday mode: False
```